### PR TITLE
Adds missing Android custom metadata code formatting

### DIFF
--- a/ingredients/events/custom_events.md
+++ b/ingredients/events/custom_events.md
@@ -90,10 +90,11 @@ Branch.getInstance().userCompletedAction("purchase", withState: ["item" : "123-A
 <!--- /iOS -->
 
 {% if page.android %}
+{% highlight java %}
 JSONObject metaData = new JSONObject();
 metaData.put("key", "value");
 Branch.getInstance().userCompletedAction("custom_action_with_data", metaData);
-
+{% endhighlight %}
 {% endif %}
 <!--- /Android -->
 


### PR DESCRIPTION
The example code for attaching custom metadata on Android was missing code formatting.