### PR TITLE
fixing TMTA data key vallue params to have single quotes instead of d…

### DIFF
--- a/ingredients/web_sdk/send_sms_example.md
+++ b/ingredients/web_sdk/send_sms_example.md
@@ -17,7 +17,7 @@ Here is a fully-functional web page that you can use as a template for your text
                     channel: 'Website',
                     feature: 'TextMeTheApp',
                     data: {
-                        "foo": "bar"
+                        'foo': 'bar'
                     }
                 };
                 var options = {};


### PR DESCRIPTION
fixing TMTA data key vallue params to have single quotes instead of double. We had partners that this caused issues for, as using double quotes around the key or value instead of single results in invalid/text not being sent.

@dmitrig01 @aaustin let me know if this is good to merge.