### PR TITLE
Some reformatting and step simplification

### DIFF
--- a/pages/getting-started/sdk-integration-guide.md
+++ b/pages/getting-started/sdk-integration-guide.md
@@ -169,7 +169,7 @@ Branch requires ARC, and we don’t intend to add `if` checks throughout the SDK
 {% endprotip %}
 
 {% caution title="For Android projects" %}
-We attempt to automatically add an Android manifest flag to support deeplinking, but check it before building your project. You may need to click the "Update Android Manifest" button to add it yourself.
+We attempt to automatically add an Android manifest flag to support deep linking, but check it before building your project. You may need to click the "Update Android Manifest" button to add it yourself.
 {% endcaution %}
 
 {% endif %}
@@ -476,7 +476,7 @@ Branch opens your app by using its URI scheme (`yourapp://`), which should be un
 {% endhighlight %}
 
 {% caution %}
-To ensure proper deeplinking from other apps such as Facebook, this Activity must be launched in `singleTask` mode. This is done in the Activity definition as so:
+To ensure proper deep linking from other apps such as Facebook, this Activity must be launched in `singleTask` mode. This is done in the Activity definition as so:
 
 {% highlight xml %}
 <activity
@@ -490,7 +490,7 @@ To ensure proper deeplinking from other apps such as Facebook, this Activity mus
 
 ## Start a Branch session
 
-A Branch session needs to be started every single time your app opens. We check to see if the user came from a link and if so, the callback method returns any deeplink parameters for that link. Please note that the callback function is always called, even when the network is out.
+A Branch session needs to be started every single time your app opens. We check to see if the user came from a link and if so, the callback method returns any deep link parameters for that link. Please note that the callback function is always called, even when the network is out.
 
 <!---    iOS -->
 {% if page.ios %}
@@ -799,13 +799,11 @@ public class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDe
 {% endif %}
 
 {% if page.unity %}
-Insert the following methods into the main class of the scene to which you added BranchPrefab. The callback method should be visible from every scene in which you will use deeplinked data.
+Insert the following methods into the main class of the scene to which you added BranchPrefab. The callback method should be visible from every scene in which you will use deep linked data.
 
-**Important note**: Please call initSession(..) in Start of your very first scene. Branch needs time to register for all of the iOS lifecycle calls before iOS calls them, in order to intercept the deep link data. If you call it after, you'll potentially miss data.
-
-{% protip %}
-Don't worry about several instances of Branch SDK, even if the scene containing BranchPrefab will be launched several times (for example: a content loading scene).
-{% endprotip %}
+{%caution %}
+Please call `initSession()` in Start of your very first scene. Branch needs time to register for all of the iOS lifecycle calls before iOS calls them, in order to intercept the deep link data. If you call it after, you'll potentially miss data.
+{% endcaution %}
 
 {% highlight c# %}
 using UnityEngine;
@@ -826,6 +824,10 @@ public class MyCoolBehaviorScript : MonoBehaviour {
     }
 }
 {% endhighlight %}
+
+{% protip %}
+Don't worry about several instances of Branch SDK, even if the scene containing BranchPrefab will be launched several times (for example: a content loading scene).
+{% endprotip %}
 
 
 {% endif %}

--- a/pages/getting-started/sdk-integration-guide.md
+++ b/pages/getting-started/sdk-integration-guide.md
@@ -801,6 +801,8 @@ public class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDe
 {% if page.unity %}
 Insert the following methods into the main class of the scene to which you added BranchPrefab. The callback method should be visible from every scene in which you will use deeplinked data.
 
+**Important note**: Please call initSession(..) in Start of your very first scene. Branch needs time to register for all of the iOS lifecycle calls before iOS calls them, in order to intercept the deep link data. If you call it after, you'll potentially miss data.
+
 {% protip %}
 Don't worry about several instances of Branch SDK, even if the scene containing BranchPrefab will be launched several times (for example: a content loading scene).
 {% endprotip %}

--- a/pages/getting-started/sdk-integration-guide.md
+++ b/pages/getting-started/sdk-integration-guide.md
@@ -75,48 +75,45 @@ You can also install the SDK manually by [downloading the latest version](https:
 <!--- Cordova -->
 {% if page.cordova %}
 
+### Register a URI scheme
+
+{% ingredient universal-links-requirement %}{% endingredient %}
+
+Branch opens your app by using its URI scheme (`yourapp://`), which should be unique to your app.
+
+1. On the [Link Settings](https://dashboard.branch.io/#/settings/link) page of the Branch dashboard.
+1. For iOS projects, ensure that **I have an iOS App** is checked and **iOS URI Scheme** is filled.
+1. For Android projects, ensure that **I have an Android App** is checked and **Android URI Scheme** is filled.
+
 ### Command line module install
 
-**Install parameters:**
-* `BRANCH_LIVE_KEY` - Your Branch live API key. You can sign up for your own Branch key at [https://dashboard.branch.io](https://dashboard.branch.io).
-* `URI_SCHEME` - It could be your app name or the URI set in your Branch dashboard. As a reminder, the URI scheme is what you use to open your app from a browser, i.e. `yourapp://`.
-* [optional] `ENCODED_ID` - This is for supporting App Links (6.0+) on Android. You can obtain the encodied id from the Branch dashboard. Just append `--variable ENCODED_ID=your-encoded-id` to the plugin install command below. For more info about App Links, please see [this](https://github.com/BranchMetrics/Android-Deferred-Deep-Linking-SDK/blob/master/README.md#leverage-android-app-links-for-deep-linking) section of the Android readme.
+You can install the Branch SDK by using one of several different command line tools. Here are the install parameters to use:
+
+| Parameter | Usage
+| --- | ---
+| `BRANCH_LIVE_KEY` | Your Branch live API key, retrieved from the [Settings page](https://dashboard.branch.io/#/settings) of the Branch dashboard.
+| `URI_SCHEME` | The URI scheme for your app (**not** including `://`) from the step above.
 
 {% tabs %}
 {% tab cordova %}
 {% highlight sh %}
-cordova plugin install https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=<your-branch-key> --variable URI_SCHEME=<your-app-uri-scheme-without-colon-and-slashes>
+cordova plugin install https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=key_live_xxxxxxxxxxxxxxx --variable URI_SCHEME=yourApp
 {% endhighlight %}
 
-example:
-
-{% highlight sh %}
-cordova plugin install https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=key_live_gchnKkd3l3m9YBPP2d73jmfejkcgVjgM --variable URI_SCHEME=branchsters
-{% endhighlight %}
 {% endtab %}
 
 {% tab phonegap %}
 {% highlight sh %}
-phonegap plugin add https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=your-branch-key --variable URI_SCHEME=your-app-uri-scheme --variable ENCODED_ID=your-encoded-id
+phonegap plugin add https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=key_live_xxxxxxxxxxxxxxx --variable URI_SCHEME=yourApp
 {% endhighlight %}
 
-example:
-
-{% highlight sh %}
-phonegap plugin add https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=key_live_gchnKkd3l3m9YBPP2d73jmfejkcgVjgM --variable URI_SCHEME=branchsters
-{% endhighlight %}
 {% endtab %}
 
 {% tab npm %}
 {% highlight sh %}
-npm install branch-cordova-sdk --variable BRANCH_LIVE_KEY=your-branch-key --variable URI_SCHEME=your-app-uri-scheme --variable ENCODED_ID=your-encoded-id
+npm install branch-cordova-sdk --variable BRANCH_LIVE_KEY=key_live_xxxxxxxxxxxxxxx --variable URI_SCHEME=yourApp
 {% endhighlight %}
 
-example:
-
-{% highlight sh %}
-npm install branch-cordova-sdk --variable BRANCH_LIVE_KEY=key_live_gchnKkd3l3m9YBPP2d73jmfejkcgVjgM --variable URI_SCHEME=branchsters
-{% endhighlight %}
 {% endtab %}
 
 {% endtabs %}
@@ -341,38 +338,6 @@ Branch opens your app by using its URI scheme (`yourapp://`), which should be un
 </intent-filter>
 {% endhighlight %}
 
-{% endif %}
-
-
-{% if page.cordova %}
-### iOS: Enable Universal Links
-
-In iOS 9.2, Apple dropped support for URI scheme redirects. You must enable Universal Links if you want Branch-generated links to work in your iOS app. To do this:
-
-1. enable `Associated Domains` capability on the Apple Developer portal when you create your app's bundle identifier.
-2. In your [Dashboard Link Settings](https://dashboard.branch.io/#/settings/link), tick the `Enable Universal Links` checkbox and provide the Bundle Identifier and Apple Team ID in the appropriate boxes.
-3. Finally, add `associated-domains` to your entitlements file. Since cordova doesn't have a way to a create entitlements and associate it to your generated project, we
-will generate the said file with the help of [Cordova Universal Links Plugin](https://github.com/nordnet/cordova-universal-links-plugin), a third plarty plugin.
-
-**Note:** The purpose of the said plugin is to generate an entitlements file and associate it to your generated project. No other implementations from the plugin are need as this guide will cover what only needs to be implemented.
-
-To start, go to your project root and install the plugin:
-
-{% highlight sh %}
-cordova plugin add cordova-universal-links-plugin
-{% endhighlight %}
-
-After the installation, add the following entry to your application's `config.xml`:
-
-{% highlight xml %}
-<universal-links>
-    <ios-team-id value=your_ios_team_id />
-    <host name="bnc.lt">
-    </host>
-</universal-links>
-{% endhighlight %}
-
-You can get your iOS Team ID from the Apple Developer Portal. Once done, you have successfully enabled universal links for iOS.
 {% endif %}
 
 {% if page.adobe %}

--- a/pages/getting-started/universal-app-links.md
+++ b/pages/getting-started/universal-app-links.md
@@ -100,16 +100,13 @@ If you use a custom domain or subdomain for your Branch links, you should also a
 {% endif %}
 
 {% if page.cordova %}
-In iOS 9.2, Apple dropped support for URI scheme redirects. You must enable Universal Links if you want Branch-generated links to work in your iOS app. To do this:
 
-1. Enable `Associated Domains` capability on the Apple Developer portal when you create your app's bundle identifier.
-2. In your [Dashboard Link Settings](https://dashboard.branch.io/#/settings/link), tick the `Enable Universal Links` checkbox and provide the Bundle Identifier and Apple Team ID in the appropriate boxes.
-3. Finally, add `associated-domains` to your entitlements file. Since cordova doesn't have a way to a create entitlements and associate it to your generated project, we
-will generate the said file with the help of [Cordova Universal Links Plugin](https://github.com/nordnet/cordova-universal-links-plugin), a third plarty plugin.
+Unfortunately Cordova doesn't have a way to a create entitlements and associate them to your generated Xcode project, so we will make use of the third-party [Cordova Universal Links Plugin](https://github.com/nordnet/cordova-universal-links-plugin).
 
-**Note:** The purpose of the said plugin is to generate an entitlements file and associate it to your generated project. No other implementations from the plugin are need as this guide will cover what only needs to be implemented.
+{% protip %}Our use of the Universal Links Plugin is simply to generate an entitlements file and associate it to your generated project. This guide covers all the steps you need to take, and no other implementations from the plugin are necessary since Branch handles everything else behind the scenes.
+{% endprotip %}
 
-To start, go to your project root and install the plugin:
+Go to your project root and install the plugin:
 
 {% highlight sh %}
 cordova plugin add cordova-universal-links-plugin
@@ -125,7 +122,7 @@ After the installation, add the following entry to your application's `config.xm
 </universal-links>
 {% endhighlight %}
 
-You can get your iOS Team ID from the Apple Developer Portal.
+You can get your iOS Team ID from the Your Account page on the [Apple Developer Portal](https://developer.apple.com/membercenter/index.action#accountSummary).
 {% endif %}
 
 {% if page.titanium %}
@@ -301,7 +298,7 @@ After completing this guide and installing a new build of your app on your testi
 {% ingredient quickstart-prerequisite %}{% endingredient %}
 {% else %}
 {% protip %}
-The following steps are only required if you wish you enable Android App Links, 
+The following steps are only required if you wish you enable Android App Links. 
 {% endprotip %}
 {% endif %}
 
@@ -322,6 +319,44 @@ Start by generating a SHA256 fingerprint of your app's signing certificate. This
 You can insert both your debug and production fingerprints for testing. Simply separate them with a comma.
 {% endprotip %}
 
+{% if page.cordova %}
+
+## Configure project
+
+The SDK plugin will automatically configure everything necessary to support App Links. You simply need to rerun the [plugin installation command]({{base.url}}/getting-started/sdk-integration-guide/guide/cordova/#command-line-module-install):
+
+1. Use the same Branch key and URI scheme values as when you installed the plugin.
+1. Append `--variable ENCODED_ID=READ_FROM_DASHBOARD` to the installation command.
+   - Replace `READ_FROM_DASHBOARD` with the four-character value provided underneath the **SHA256 Cert Fingerprints** field on the Branch dashboard. It will look something like this: `WSuf`
+
+Here is an example of the full plugin installation command:
+
+{% tabs %}
+{% tab cordova %}
+{% highlight sh %}
+cordova plugin install https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=key_live_xxxxxxxxxxxxxxx --variable URI_SCHEME=yourApp --variable ENCODED_ID=READ_FROM_DASHBOARD
+{% endhighlight %}
+
+{% endtab %}
+
+{% tab phonegap %}
+{% highlight sh %}
+phonegap plugin add https://github.com/BranchMetrics/Cordova-Ionic-PhoneGap-Deferred-Deep-Linking-SDK.git --variable BRANCH_LIVE_KEY=key_live_xxxxxxxxxxxxxxx --variable URI_SCHEME=yourApp --variable ENCODED_ID=READ_FROM_DASHBOARD
+{% endhighlight %}
+
+{% endtab %}
+
+{% tab npm %}
+{% highlight sh %}
+npm install branch-cordova-sdk --variable BRANCH_LIVE_KEY=key_live_xxxxxxxxxxxxxxx --variable URI_SCHEME=yourApp --variable ENCODED_ID=READ_FROM_DASHBOARD
+{% endhighlight %}
+
+{% endtab %}
+
+{% endtabs %}
+
+{% else %}
+
 ## Add Intent Filter to Manifest
 
 1. Choose the `Activity` you want to open up when a link is clicked. This is typically your `SplashActivity` or a `BaseActivity` that all other activities inherit from (and likely the same one you selected in the [SDK Integration Guide]({{base.url}}/getting-started/sdk-integration-guide)).
@@ -339,6 +374,8 @@ You can insert both your debug and production fingerprints for testing. Simply s
     <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="READ_FROM_DASHBOARD" /> <!-- Live App link-->
 </intent-filter>
 {% endhighlight %}
+
+{% endif %}
 
 ## Test your App Links implementation
 


### PR DESCRIPTION
@aaustin 

Tweaks:

1. Converted the installation command parameters into a table ([here](https://github.com/BranchMetrics/documentation/compare/cordova-2-0-tweaks?expand=1#diff-aeba1c29195c68d364092cfa8e1c71bfR92))
1. Updated the installation command's value stubs to match those used on other platforms ([here](https://github.com/BranchMetrics/documentation/compare/cordova-2-0-tweaks?expand=1#diff-aeba1c29195c68d364092cfa8e1c71bfR100), [here](https://github.com/BranchMetrics/documentation/compare/cordova-2-0-tweaks?expand=1#diff-aeba1c29195c68d364092cfa8e1c71bfR107), and [here](https://github.com/BranchMetrics/documentation/compare/cordova-2-0-tweaks?expand=1#diff-aeba1c29195c68d364092cfa8e1c71bfR104))
1. Removed the Universal Links section from the SDK integration guide, since it duplicated the main UL guide
1. Simplified the Universal Links guide steps, since there were some duplications with earlier/later sections of the guide ([here](https://github.com/BranchMetrics/documentation/compare/cordova-2-0-tweaks?expand=1#diff-ef424c23f2a2d91389506bfaed934ecfR104))
1. Moved the App Links instructions to the App Links guide ([here](https://github.com/BranchMetrics/documentation/compare/cordova-2-0-tweaks?expand=1#diff-ef424c23f2a2d91389506bfaed934ecfR324))