### PR TITLE
Some page titles were not showing up

### DIFF
--- a/pages/features/content-sharing.md
+++ b/pages/features/content-sharing.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: features
 title: "Content Sharing"
-ios_page_title: iOS Deep Links for Content Sharing
-android_page_title: Android Deep Links for Content Sharing
-ios_description: How to create deep links programmatically to share content and how to route to content within your iOS app. With objective-c and swift code snippets.
-android_description: How to create deep links programmatically to share content and how to route to content within your Android app. With code snippets.
+page_title: Deep Links for Content Sharing
+description: How to create deep links programmatically to share content and how to route to content within your app. With code snippets.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Content Sharing, Content, Routing, SMS, iOS, objective-c, swift
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views,Content Sharing, Content, Routing, SMS, Android
 platforms:

--- a/pages/features/custom-onboarding.md
+++ b/pages/features/custom-onboarding.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: features
 title: Custom Onboarding
-ios_page_title: Personalized Onboarding Flow for iOS Apps
-android_page_title: Personalized Onboarding for Android Apps
-ios_description: How to set up a personalized invite system and onboarding flow for iOS Apps using Branch deep links. With objective-c and swift code snippets.
-android_description: How to set up a personalized invite system and onboarding flow for Android Apps using Branch deep links. With code snippets.
+page_title: Personalized Onboarding Flow for Apps
+description: How to set up a personalized invite system and onboarding flow for Apps using Branch deep links. With code snippets.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Personalized onboarding, onboarding, welcome screen, iOS, objective-c, swift
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Personalized onboarding, onboarding, welcome screen, Android
 platforms:

--- a/pages/features/email-campaigns.md
+++ b/pages/features/email-campaigns.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: features
 title: Email Campaigns
-ios_page_title: Email campaigns with deep links for iOS
-android_page_title: Email campaigns with Android deep links
-ios_description: How to create marketing links for email campaigns featuring your iOS app. Branch Links enable deep linking, install attribution, and in-depth analytics.
-android_description: How to create deep links for email campaigns featuring your Android app. Branch Links enable deep linking, install attribution, and in-depth analytics.
+page_title: Email campaigns with deep links
+description: How to create deep links for email campaigns featuring your app. Branch Links enable deep linking, install attribution, and in-depth analytics.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, email campaigns, marketing links
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views,email campaigns, marketing links, Android
 hide_platform_selector: true

--- a/pages/features/facebook-app-invites.md
+++ b/pages/features/facebook-app-invites.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: features
 title: "Facebook App Invites"
-ios_page_title: Set up Facebook App Invites for iOS Apps
-android_page_title: Facebook App Invites for Android Apps
-ios_description: How to set up Facebook App Invites and ad campaigns for your iOS app using Branch deep links. With objective-c and swift code snippets.
-android_description: How to set up Facebook App Invites and ad campaigns for your Android app using Branch deep links. With Java code snippets.
+page_title: Set up Facebook App Invites for Apps
+description: How to set up Facebook App Invites and ad campaigns for your app using Branch deep links. With code snippets.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Facebook App Invites, App Invites, iOS, objective-c, swift
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views,Facebook App Invites, App Invites, Android
 platforms:

--- a/pages/features/index.md
+++ b/pages/features/index.md
@@ -2,8 +2,8 @@
 type: landing
 directory: features
 title: "Features"
-page_title: "Set up Android App Links with Branch"
-description: "Learn how to enable Android App Links on with Branch deep links for tracking and deep linking."
+page_title: "Deep linking features with Branch"
+description: "Learn about the deep linking features offered by Branch."
 keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Android App Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Dashboard, iOS9
 hide_platform_selector: true
 hide_section_selector: true

--- a/pages/features/referral-programs.md
+++ b/pages/features/referral-programs.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: features
 title: "Referral Programs"
-ios_page_title: Creating referral programs for iOS apps
-android_page_title: Creating referral programs for iOS apps
-ios_description: How to set up Referral Links and Reward Schemes for iOS apps using deep links.
-android_description: How to set up App Invites, Referral Links and Reward Schemes for Android apps using deep links.
+page_title: Creating referral programs for apps
+description: How to set up App Invites, Referral Links and Reward Schemes for apps using deep links.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Referral Links, App Invites, Reward Schemes, Promotion codes, iOS, objective-c, swift
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Referral Links, App Invites, Reward Schemes, Promotion codes, Android
 platforms:

--- a/pages/features/twitter-ads.md
+++ b/pages/features/twitter-ads.md
@@ -2,6 +2,7 @@
 type: recipe
 directory: features
 title: "Twitter Ads"
+page_title: "Twitter Ads"
 hide_platform_selector: true
 sections:
 - overview

--- a/pages/third-party-integrations/google-analytics.md
+++ b/pages/third-party-integrations/google-analytics.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: third-party-integrations
 title: "Google Analytics"
-ios_page_title: Send iOS Deep Link Data to Google Analytics
-android_page_title: Use Android Link Data in Google Analytics
-ios_description: This guide teaches you how to find and send iOS deep link data to Google Analytics through your Branch Metrics implementation.
-android_description: This guide teaches you how to find and send Android deep link data to Google Analytics through your Branch Metrics implementation.
+page_title: Send Deep Link Data to Google Analytics
+description: This guide teaches you how to find and send deep link data to Google Analytics through your Branch Metrics implementation.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Google Analytics, iOS, Webhook
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Google Analytics, Android, Webhook
 platforms:

--- a/pages/third-party-integrations/mixpanel.md
+++ b/pages/third-party-integrations/mixpanel.md
@@ -2,10 +2,8 @@
 type: recipe
 directory: third-party-integrations
 title: "Mixpanel"
-ios_page_title: Sync Branch iOS data with Mixpanel
-android_page_title: Sync Branch Android data with Mixpanel
-ios_description: Learn how to synchronize your Branch iOS data with Mixpanel, for example to track in-app events, segment users from Branch installs and calculate LTV.
-android_description: Learn how to synchronize your Branch Android data with Mixpanel, for example to track in-app events, segment users from Branch installs and calculate LTV.
+page_title: Sync Branch data with Mixpanel
+description: Learn how to synchronize your Branch data with Mixpanel, for example to track in-app events, segment users from Branch installs and calculate LTV.
 ios_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Mixpanel, user segmentation, life time value, LTV
 android_keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Mixpanel, user segmentation, life time value, LTV
 platforms:

--- a/pages/third-party-integrations/referral-saasquatch.md
+++ b/pages/third-party-integrations/referral-saasquatch.md
@@ -2,6 +2,7 @@
 type: recipe
 directory: third-party-integrations
 title: "Referral SaaSquatch"
+page_title: "Using Branch and Referral Saasquatch together"
 platforms:
 - ios
 - android


### PR DESCRIPTION
@lilabjorg looks like platform-specific page titles weren't getting processed. Those were only left from the old portal on a few pages, so I removed them. Does this look good?