### PR TITLE
Fix the example to be functional

### DIFF
--- a/pages/features/smart-banner.md
+++ b/pages/features/smart-banner.md
@@ -72,7 +72,7 @@ branch.banner(options, {
 {% highlight javascript %}
 branch.banner(options, {
     data: {
-      '$deeplink_path': window.location.split('com/')[1],
+      '$deeplink_path': window.location.pathname + window.location.search + window.location.hash,
     }
 });
 {% endhighlight %}


### PR DESCRIPTION
The previous example was only for .com urls, and didn't actually work with those (window.location is not a string)

@aaustin 