### PR TITLE
[HOLD for testing & deploy] started section for web-only links

### DIFF
--- a/pages/getting-started/configuring-links.md
+++ b/pages/getting-started/configuring-links.md
@@ -111,6 +111,18 @@ This parameter is currently supported only on iOS.
 | --- | ---
 | $after_click_url | URL redirect to after the main click redirect has completed
 
+#### Web-only links
+
+This lets you direct the user to the web, *even if they have the app installed*. 
+
+{% caution %}
+This parameter is currently supported only on iOS.
+{% endcaution %}
+
+| Key | Value | Default
+| --- | --- | ---
+| $web_only | TODO | todo
+
 ### Link behavior customization
 
 Use these keys to control how URI scheme deep linking functions when opening your app from a link.

--- a/pages/getting-started/configuring-links.md
+++ b/pages/getting-started/configuring-links.md
@@ -120,7 +120,7 @@ Then the URL will include `/e/`, which is short for "exclusion". These links are
 Aliased links are supported. `/e/` will be inserted into the URL, e.g. `myapp.app.link/e/myalias`. When you create an aliased link, the alias you reserve is for both forms of the url, e.g. `myapp.app.link/myalias` and `myapp.app.link/e/myalias`. This is effectively the same link, though the web-only form will not open the app even if it is installed.
 
 {% caution %}
-This parameter is currently supported only on iOS.
+This parameter will not work with [Android App Links]({{base.url}}/getting-started/universal-app-links/).
 {% endcaution %}
 
 | Key | Value | Default

--- a/pages/getting-started/configuring-links.md
+++ b/pages/getting-started/configuring-links.md
@@ -113,7 +113,11 @@ This parameter is currently supported only on iOS.
 
 #### Web-only links
 
-This lets you direct the user to the web, *even if they have the app installed*. 
+This lets you direct the user to the web, *even if they have the app installed*. When creating the link, add `$web_only: true` to the deep link data. 
+
+Then the URL will include `/e/`, which is short for "exclusion". These links are excluded in the apple-app-site-association file we generate for custom domains and app.link domains. Note that bnc.lt links will not have `/e/` in the URL, but rather will revert to their non-Universal form, `/m/`.
+
+Aliased links are supported. `/e/` will be inserted into the URL, e.g. `myapp.app.link/e/myalias`. When you create an aliased link, the alias you reserve is for both forms of the url, e.g. `myapp.app.link/myalias` and `myapp.app.link/e/myalias`. This is effectively the same link, though the web-only form will not open the app even if it is installed.
 
 {% caution %}
 This parameter is currently supported only on iOS.
@@ -121,7 +125,12 @@ This parameter is currently supported only on iOS.
 
 | Key | Value | Default
 | --- | --- | ---
-| $web_only | TODO | todo
+| $web_only | true/false | false (not specified)
+
+{% protip title="Do you use Branch links in email?" %}
+Note: if your Branch links are wrapped by an email service provider's click tracking domain, then this logic does not apply. The email service provider must allow you to designate links as web-only links, because they control how click tracking links are created.
+{% endprotip %}
+
 
 ### Link behavior customization
 


### PR DESCRIPTION
@derrickstaten added a section in getting started > configuring links, under Link Control Parameters, Redirect Customization (http://127.0.0.1:4000/getting-started/configuring-links/#web-only-links)

I think we can keep it real brief.