### PR TITLE
remove weibo flag and add android_wechat

### DIFF
--- a/pages/getting-started/configuring-links.md
+++ b/pages/getting-started/configuring-links.md
@@ -97,7 +97,7 @@ The redirect destinations are completely customizable for every link that you cr
 | $blackberry_url | Change the redirect endpoint for Blackberry OS | BlackBerry default URL (set in [Link Settings](https://dashboard.branch.io/#/settings/link))
 | $fire_url | Change the redirect endpoint for Amazon Fire OS | Fire default URL (set in [Link Settings](https://dashboard.branch.io/#/settings/link))
 | $ios_wechat_url | Change the redirect endpoint for WeChat on iOS devices | `$ios_url` value
-| $ios_weibo_url | Change the redirect endpoint for Weibo on iOS devices | `$ios_url` value
+| $android_wechat_url | Change the redirect endpoint for WeChat on Android devices | `$android_url` value
 
 #### After click redirect
 


### PR DESCRIPTION
We don't have any ios_weibo flag in our LS code. However, we have an android_wechat_url flag that we don't advertise on the docs so I am swapping these values.

@dwestgate cc @aaustin 