### PR TITLE
Replace deeplink with deep link

### DIFF
--- a/pages/third-party-integrations/apptimize.md
+++ b/pages/third-party-integrations/apptimize.md
@@ -3,7 +3,7 @@ type: recipe
 directory: third-party-integrations
 title: "Apptimize"
 page_title: Deep link users through install, and test the best user flow automatically.
-description: Branch has partnered with Apptimize to seamlessly A/B test user flows after a deeplink click from Branch. 
+description: Branch has partnered with Apptimize to seamlessly A/B test user flows after a deeplink click from Branch.
 keywords: abtesting, apptimize
 platforms:
 - ios
@@ -16,7 +16,7 @@ sections:
 
 {% if page.overview %}
 
-Branch has partnered with Apptimize to seamlessly provide different onboarding flows for users arriving through Branch links. You can design and test different user flows based off the data a Branch deeplink returns to you. Have a theory that users clicking Branch links right into a product page convert better than users clicking Branch links but must authenticate first? With this integration, you can define, measure, and prove your hypothesis!
+Branch has partnered with Apptimize to seamlessly provide different onboarding flows for users arriving through Branch links. You can design and test different user flows based off the data the Branch deep link returns to you. Have a theory that users clicking Branch links right into a product page convert better than users clicking Branch links, but must authenticate first? With this integration, you can define, measure, and prove your hypothesis!
 
 {% image src='/img/pages/third-party-integrations/apptimize/campaign-flow.png' full center alt='Apptimize flow example' %}
 
@@ -50,7 +50,7 @@ Next, segment users into your campaign using the Apptimize dashboard. We have se
 
 ## Set targeting in your app
 
-You need to decide *where* to define a user attribute from the previous step. Setting this in the callback found inside your {% if page.ios %}`AppDelegate.m`{% endif %}{% if page.android %} `BaseActivity` or `SplashActivity`{% endif %} is the simplest approach, but you can do it anywhere. 
+You need to decide *where* to define a user attribute from the previous step. Setting this in the callback found inside your {% if page.ios %}`AppDelegate.m`{% endif %}{% if page.android %} `BaseActivity` or `SplashActivity`{% endif %} is the simplest approach, but you can do it anywhere.
 
 {% if page.ios %}
 

--- a/pages/third-party-integrations/apptimize.md
+++ b/pages/third-party-integrations/apptimize.md
@@ -3,7 +3,7 @@ type: recipe
 directory: third-party-integrations
 title: "Apptimize"
 page_title: Deep link users through install, and test the best user flow automatically.
-description: Branch has partnered with Apptimize to seamlessly A/B test user flows after a deeplink click from Branch.
+description: Branch has partnered with Apptimize to seamlessly A/B test user flows after a deep link click from Branch.
 keywords: abtesting, apptimize
 platforms:
 - ios

--- a/pages/third-party-integrations/referral-saasquatch.md
+++ b/pages/third-party-integrations/referral-saasquatch.md
@@ -13,7 +13,7 @@ sections:
 
 {% if page.overview %}
 
-[Referral SaaSquatch](http://www.referralsaasquatch.com/) is a cross-platform customer referral program platform. In addition to mobile, SaaSquatch also works with desktop, web, telecom, ecommerce, and enterprise companies to power their referral programs across channels. The Branch + Referral SaaSquatch integration lets you run a referral program with any combination of web and mobile, using the power of Branch deeplinking and Referral SaaSquatch's widgets, referral graph, reward bank, and administration features. 
+[Referral SaaSquatch](http://www.referralsaasquatch.com/) is a cross-platform customer referral program platform. In addition to mobile, SaaSquatch also works with desktop, web, telecom, ecommerce, and enterprise companies to power their referral programs across channels. The Branch + Referral SaaSquatch integration lets you run a referral program with any combination of web and mobile, using the power of Branch deep linking and Referral SaaSquatch's widgets, referral graph, reward bank, and administration features.
 
 The Branch + SaaSquatch referral program integration provides:
 
@@ -25,8 +25,8 @@ The Branch + SaaSquatch referral program integration provides:
 
 {% example title="Other implementation ideas" %}
 
-Referral SaaSquatch supports referral tracking across platforms and mediums. 
-For example you could invite a friend to try a product using your iPhone, but then their friends might sign up for an account using Chrome on their laptop, and then install your Android app to make their first purchase. 
+Referral SaaSquatch supports referral tracking across platforms and mediums.
+For example you could invite a friend to try a product using your iPhone, but then their friends might sign up for an account using Chrome on their laptop, and then install your Android app to make their first purchase.
 
 Some other possibilities:
 
@@ -96,13 +96,13 @@ builder.scheme("https")
     .appendQueryParameter("firstName", user.getFirstName())
     .appendQueryParameter("accountId", user.getCompanyId())
     .appendQueryParameter("email", user.getEmail())
-    
-    // If available connect referralCode from Branch deeplink to trigger attribution
+
+    // If available connect referralCode from Branch deep link to trigger attribution
     //.appendQueryParameter("referralCode", TODO)
-    
+
     // If status is available, include it here to trigger conversions
     //.appendQueryParameter("accountStatus", "PAID")
-    
+
     .appendQueryParameter("paymentProviderId", "NULL");
 
 String widgetUrl = builder.build().toString();
@@ -193,7 +193,7 @@ public void onStart() {
                         String rewardText = "You can get " + referringParams.getString("sq_quantity") + "% off your bill!";
                         TextView reward = (TextView) findViewById(R.id.reward);
                         reward.setText(rewardText);
-                        
+
                         // TODO: Connect this with the Widget code shown above to complete attribution once a user authenticates
                         String referralCode = referringParams.getString("sq_referralCode");
 
@@ -211,6 +211,6 @@ public void onStart() {
 
 ## Conclusion
 
-You now have the foundation for an incentivized referral program. Like many popular promo-code systems, you can reward both the user who shares a link and the user who clicks the link and purchases in the app. 
+You now have the foundation for an incentivized referral program. Like many popular promo-code systems, you can reward both the user who shares a link and the user who clicks the link and purchases in the app.
 
 {% endif %}


### PR DESCRIPTION
Small commit to put the docs back in line with Branch deep link naming convention. 

CC @dwestgate & @ahmednawar 