### PR TITLE
Added alternate domain for setting up Android Applinks.

### DIFF
--- a/pages/getting-started/universal-app-links.md
+++ b/pages/getting-started/universal-app-links.md
@@ -458,6 +458,7 @@ If the **Default domain name** box shows the legacy `bnc.lt` domain, you should 
     <category android:name="android.intent.category.DEFAULT" />
     <category android:name="android.intent.category.BROWSABLE" />
     <data android:scheme="https" android:host="xxxx.app.link" />
+    <data android:scheme="https" android:host="xxxx-alternate.app.link" />
 </intent-filter>
 {% endhighlight %}
 


### PR DESCRIPTION
Android teams that are silo'd from iOS easily miss the -alternate piece.