### PR TITLE
Added swift examples for the iOS mParticle-only code.

### DIFF
--- a/pages/getting-started/deep-link-routing.md
+++ b/pages/getting-started/deep-link-routing.md
@@ -254,9 +254,12 @@ branch.subscribe((bundle) => {
 {% endif %}
 
 {% if page.mparticle_ios %}
+{% tabs %}
+{% tab objective-c %}
 Inside the callback for `checkForDeferredDeepLinkWithCompletionHandler` method in your AppDelegate, examine the params dictionary to determine whether the user opened a link to content. Below is an example assuming that the links correspond to pictures.
 
-{% highlight objc %}- (void)checkForDeeplink {
+{% highlight objc %}
+- (void)checkForDeeplink {
     MParticle * mParticle = [MParticle sharedInstance];
 
     [mParticle checkForDeferredDeepLinkWithCompletionHandler:^(NSDictionary<NSString *,NSString *> * _Nullable params, NSError * _Nullable error) {
@@ -283,6 +286,27 @@ Inside the callback for `checkForDeferredDeepLinkWithCompletionHandler` method i
     }];
 }
 {% endhighlight %}
+{% endtab %}
+{% tab swift %}
+Inside the callback for `checkForDeferredDeepLink` method in your AppDelegate, examine the linkInfo dictionary to determine whether the user opened a link to content. Below is an example assuming that the links correspond to pictures.
+
+{% highlight swift %}
+func checkForDeepLink() {
+    MParticle.sharedInstance().checkForDeferredDeepLink { linkInfo, error in
+        guard let linkInfo = linkInfo else {return }
+
+        if error == nil && linkInfo["+clicked_branch_link"] != nil && linkInfo["pictureId"] != nil {
+            print("Clicked picture link!")
+
+            // Load the view to show the picture
+        } else {
+            // Load your normal view
+        }
+    }
+}
+{% endhighlight %}
+{% endtab %}
+{% endtabs %}
 {% endif %}
 
 {% if page.mparticle_android %}

--- a/pages/getting-started/sdk-integration-guide.md
+++ b/pages/getting-started/sdk-integration-guide.md
@@ -1205,6 +1205,8 @@ public class MainActivity extends ReactActivity {
 
 ## Handle Incoming Links
 
+{% tabs %}
+{% tab objective-c %}
 1. In Xcode, open your **AppDelegate.m** file.
 1. In the `didFinishLaunchingWithOptions` method, before you initialize your mParticle session, add the following:
 
@@ -1215,7 +1217,23 @@ NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
                            name:mParticleKitDidBecomeActiveNotification
                          object:nil];
 {% endhighlight %}
+{% endtab %}
+{% tab swift %}
+1. In Xcode, open your **AppDelegate.swift** file.
+1. In the `application:didFinishingLaunchingWithOptions:` method, before you initialize your mParticle session, add the following:
 
+{% highlight swift %}
+NotificationCenter.default.addObserver(self, selector: #selector(handleKitDidBecomeActive(_:)), name: Notification.Name.mParticleKitDidBecomeActive, object: nil)
+{% endhighlight %}
+{% endtab %}
+{% endtabs %}
+
+{% caution %}
+This observer must be added _before_ initializing the mParticle session. Failure to do so will cause some deep links to be missed.
+{% endcaution %}
+
+{% tabs %}
+{% tab objective-c %}
 Add the following methods to your **AppDelegate.m** file:
 
 {% highlight objc %}
@@ -1266,6 +1284,58 @@ Add the following methods to your **AppDelegate.m** file:
     }];
 }
 {% endhighlight %}
+{% endtab %}
+{% tab swift %}
+Add the following methods to your **AppDelegate.swift** file:
+
+{% highlight swift %}
+func handleKitDidBecomeActive(_ notification: Notification) {
+    guard let kitNumber = notification.userInfo?[mParticleKitInstanceKey] as? NSNumber else { return }
+    guard let kitInstance = MPKitInstance(rawValue: kitNumber.uintValue) else { return }
+
+    switch kitInstance {
+        case .branchMetrics:
+            checkForDeeplink()
+        default:
+            break
+    }
+}
+
+func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+    checkForDeeplink()
+    return true
+}
+
+func checkForDeeplink() {
+    MParticle.sharedInstance().checkForDeferredDeepLink { linkInfo, error in
+        // A few typical scenarios where this block would be invoked:
+        //
+        // (1) Base case:
+        //     - User does not tap on a link, and then opens the app (either after a fresh install or not)
+        //     - This block will be invoked with Branch Metrics' response indicating that this user did not tap on a link
+        //
+        // (2) Deferred deep link:
+        //     - User without the app installed taps on a link
+        //     - User is redirected from Branch Metrics to the App Store and installs the app
+        //     - User opens the app
+        //     - This block will be invoked with Branch Metrics' response containing the details of the link
+        //
+        // (3) Deep link with app installed:
+        //     - User with the app already installed taps on a link
+        //     - Application opens via openUrl/continueUserActivity, mParticle forwards launch options etc to Branch
+        //     - This block will be invoked with Branch Metrics' response containing the details of the link
+        //
+        // If the user navigates away from the app without killing it, this block could be invoked several times:
+        // once for the initial launch, and then again each time the user taps on a link to re-open the app.
+
+        guard let linkInfo = linkInfo else { return }
+
+        print("params:" + linkInfo)
+    }
+}
+{% endhighlight %}
+{% endtab %}
+{% endtabs %}
 
 {% endif %}
 <!-- mParticle - iOS -->

--- a/pages/getting-started/universal-app-links.md
+++ b/pages/getting-started/universal-app-links.md
@@ -304,6 +304,8 @@ Open your **AppDelegate.m** file and add the following method (if you completed 
 {% endif %}
 
 {% if page.mparticle_ios %}
+{% tabs %}
+{% tab objective-c %}
 Open your **AppDelegate.m** file and add the following methods (if you completed the [SDK Integration Guide]({{base.url}}/getting-started/sdk-integration-guide), these are likely already present).
 
 {% highlight objc %}
@@ -344,6 +346,46 @@ Open your **AppDelegate.m** file and add the following methods (if you completed
     }];
 }
 {% endhighlight %}
+{% endtab %}
+{% tab swift %}
+Open your **AppDelegate.swift** file and add the following methods (if you completed the [SDK Integration Guide]({{base.url}}/getting-started/sdk-integration-guide), these are likely already present).
+
+{% highlight swift %}
+func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+    checkForDeeplink()
+    return true
+}
+
+func checkForDeeplink() {
+    MParticle.sharedInstance().checkForDeferredDeepLink { linkInfo, error in
+        // A few typical scenarios where this block would be invoked:
+        //
+        // (1) Base case:
+        //     - User does not tap on a link, and then opens the app (either after a fresh install or not)
+        //     - This block will be invoked with Branch Metrics' response indicating that this user did not tap on a link
+        //
+        // (2) Deferred deep link:
+        //     - User without the app installed taps on a link
+        //     - User is redirected from Branch Metrics to the App Store and installs the app
+        //     - User opens the app
+        //     - This block will be invoked with Branch Metrics' response containing the details of the link
+        //
+        // (3) Deep link with app installed:
+        //     - User with the app already installed taps on a link
+        //     - Application opens via openUrl/continueUserActivity, mParticle forwards launch options etc to Branch
+        //     - This block will be invoked with Branch Metrics' response containing the details of the link
+        //
+        // If the user navigates away from the app without killing it, this block could be invoked several times:
+        // once for the initial launch, and then again each time the user taps on a link to re-open the app.
+
+        guard let linkInfo = linkInfo else { return }
+
+        print("params:" + linkInfo)
+    }
+}
+{% endhighlight %}
+{% endtab %}
+{% endtabs %}
 {% endif %}
 
 ## Test your Universal Links implementation


### PR DESCRIPTION
Also added a warning that the observer for the "kit loaded" event has to be added prior to the mParticle session initialization.

