### PR TITLE
Updated integration guide to use the new preferred deeplink method.

### DIFF
--- a/pages/getting-started/content-sharing-tutorial.md
+++ b/pages/getting-started/content-sharing-tutorial.md
@@ -57,7 +57,7 @@ The tutorial is broken up into six parts: integrating the Branch SDK, setting up
 6. In Xcode, open your project’s info.plist file from the project navigator
 {% image src="/img/pages/getting-started/content-sharing-tutorial/screenshots/info_plist.png" center half %}
 7. Mouse hover over “Information Property List” until a `+` appears to the right. Click it.
-8. A new row will have been added under “Information Property List.” 
+8. A new row will have been added under “Information Property List.”
 9. Edit the new row so that the key is "branch_key" and the value is the Branch Key that you copied in step 5:
 
 | Key | Type | Value |
@@ -129,7 +129,11 @@ Copy and paste the following code into **AppDelegate.swift** right before the ve
 // Respond to URI scheme links
 func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
     // pass the url to the handle deep link call
-    Branch.getInstance().handleDeepLink(url);
+    Branch.getInstance().application(application,
+        open: url,
+        sourceApplication: sourceApplication,
+        annotation: annotation
+    )
 
     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
     return true

--- a/pages/getting-started/sdk-integration-guide.md
+++ b/pages/getting-started/sdk-integration-guide.md
@@ -811,7 +811,11 @@ Finally, add these two new methods to your **AppDelegate.m** file. The first res
 // Respond to URI scheme links
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
     // pass the url to the handle deep link call
-    [[Branch getInstance] handleDeepLink:url];
+    [[Branch getInstance]
+        application:application
+            openURL:url
+  sourceApplication:sourceApplication
+         annotation:annotation];
 
     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
     return YES;
@@ -834,7 +838,11 @@ Finally, add these two new methods to your **AppDelegate.swift** file. The first
 // Respond to URI scheme links
 func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
     // pass the url to the handle deep link call
-    Branch.getInstance().handleDeepLink(url);
+    Branch.getInstance().application(application,
+        open: url,
+        sourceApplication: sourceApplication,
+        annotation: annotation
+    )
 
     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
     return true

--- a/pages/getting-started/universal-app-links.md
+++ b/pages/getting-started/universal-app-links.md
@@ -586,7 +586,11 @@ Branch *branch = [Branch getInstance];
 // Entry point for users on iOS 8 and lower
 
 -(BOOL) application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-   [[Branch getInstance] handleDeepLink:url];
+    [[Branch getInstance]
+        application:application
+            openURL:url
+  sourceApplication:sourceApplication
+         annotation:annotation];
    self.ignoreDeeplinkPath = YES;
 
    // ... your other logic here, such as ...
@@ -635,7 +639,11 @@ func application(application: UIApplication, didFinishLaunchingWithOptions launc
 // Entry point for users on iOS 8 and lower
 
 func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject) -> Bool {
-   Branch.getInstance().handleDeepLink(url)
+   Branch.getInstance().application(application,
+        open: url,
+        sourceApplication: sourceApplication,
+        annotation: annotation
+   )
    self.ignoreDeeplinkPath = true
 
    // ... your other logic here, such as ...
@@ -774,7 +782,7 @@ You can check if your Xcode project is correctly configured by using our [Univer
 Universal Links don't work properly when entered into Safari. Use Notes or iMessage for testing.
 
 ##### Are you wrapping Branch links with another link and redirecting?
-In most cases, Universal Links won't open the app when they are "wrapped" by click tracking links. Universal links, including Branch links, must be freestanding. If you want Universal Links to work in all situations, do not use other links that redirect to your Branch links. 
+In most cases, Universal Links won't open the app when they are "wrapped" by click tracking links. Universal links, including Branch links, must be freestanding. If you want Universal Links to work in all situations, do not use other links that redirect to your Branch links.
 
 ##### Do your Team ID & Bundle ID match those on your dashboard?
 You can find them in the Dashboard under Settings > Link Settings, in the iOS section next to "Enable Universal Links." They should match your Team ID and Bundle ID. Team ID can be found here [https://developer.apple.com/membercenter/index.action#accountSummary](https://developer.apple.com/membercenter/index.action#accountSummary). Your Bundle ID is found in Xcode, in the `General` tab for the correct build target. If your Apple App Prefix is different from your Team ID, you should use your App Prefix. Your app prefix can be found from App IDs on Apple's Developer Portal.


### PR DESCRIPTION
Updated integration guide to use the new preferred '[[Branch getInstance] application:application openURL:url options:options];' method instead of '[[Branch getInstance] handleDeepLink:url]'.