### PR TITLE
Fixed broken link in Deepviews page.

### DIFF
--- a/pages/marketing-channels/deepviews.md
+++ b/pages/marketing-channels/deepviews.md
@@ -73,7 +73,7 @@ Only users who do not have the app will go through this flow. You can view the t
 
 ## Customizations
 
-This is all you need to do to enable Deepviews. For each link, Branch will attempt to intelligently display the best content we have available. However, you can (and will probably want to!) customize what is shown. See the [Advanced]({{base.url}}/features/deepviews/advanced/) page for more information.
+This is all you need to do to enable Deepviews. For each link, Branch will attempt to intelligently display the best content we have available. However, you can (and will probably want to!) customize what is shown. See the [Advanced]({{base.url}}/marketing-channels/deepviews/advanced/) page for more information.
 
 {% elsif page.advanced %}
 


### PR DESCRIPTION
Although it should redirect automatically to the new endpoint, for some reason this link doesn't. I've changed it to point to the same place, but in the new /marketing-channels/ section.