### PR TITLE
Appboy push service support docs added - INTENG-3447

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -100,6 +100,9 @@
         - android-instant-apps
         - ios-imessage
         # - title: Roots SDK (MISSING)
+    - title: Push service
+      children:
+        - appboy-push-service
 - title: Cross Channel Analytics
   directory: cross-channel-analytics
   children:

--- a/pages/data-exchange/appboy.md
+++ b/pages/data-exchange/appboy.md
@@ -10,7 +10,6 @@ premium: true
 sections:
 - overview
 - guide
-- support
 alias: [ /third-party-integrations/appboy/, /third-party-integrations/appboy/overview/, /third-party-integrations/appboy/guide/, /third-party-integrations/appboy/support/ ] 
 ---
 
@@ -21,8 +20,6 @@ The Branch partnership with [Appboy](https://www.appboy.com) provides a push-but
 **At this time, our integration only applies to the iOS platform.**
 
 {% ingredient paid-integration %}{% endingredient %}
-
-{% getstarted %}{% endgetstarted %}
 
 ## How it works
 
@@ -61,52 +58,4 @@ We have built a custom integration to automatically send all Branch install data
 Branch is not responsible for inaccurate API keys.
 {% endcaution %}
 
-{% elsif page.support %}
-
-## Troubleshooting
-
-There are common strategies to take while trouble shooting.
-
-### How to use Branch Links to Deep Link from Appboy's In-App Message Campaigns on iOS
-
-1. Ensure that the type of campaign you are running is an **In-App Message** campaign.
-2. From Appboy's Dashboard, **Edit** your campaign.
-3. From the **Compose** tab scroll down to **iOS**.
-4. Within the **On-click Behavior** section, select **Deep Link Into App**.
-5. To understand what to insert into this field, find a Branch Marketing link you would like users to get deep linked to and then follow the instructions [here](https://dev.branch.io/features/facebook-ads/support/ios/#use-a-direct-deep-link).
-6. **Update** your campaign.
-7. The final step requires a code change. You'll have to modify `application:openURL:options:` so that it makes a call to:
-
-{% highlight objc %}
-[[Branch getInstance]
-     application:application
-     openURL:url
-     options:options];
-{% endhighlight %}
-
-This will replace the call to:
-
-{% highlight objc %}
-[[Branch getInstance] handleDeepLink:url];
-{% endhighlight %}
-
-Here is the method correctly implemented:
-
-{% highlight objc %}
-- (BOOL) application:(UIApplication *)application
-             openURL:(NSURL *)url
-             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-    
-    [[Branch getInstance]
-     application:application
-     openURL:url
-     options:options];
-    
-    return YES;
-}
-{% endhighlight %}
-
-**Note**: This method is available in iOS SDK version `0.14.9` and higher.
-
-Performing these changes will ensure that a tap on an **In-App Message** results in the delivery of deep link data from the link selected in **step 5**.
 {% endif %}

--- a/pages/marketing-channels/appboy-push-service.md
+++ b/pages/marketing-channels/appboy-push-service.md
@@ -1,0 +1,65 @@
+---
+type: recipe
+directory: marketing-channels
+title: "Appboy push service"
+page_title: Appboy push service
+description: We’ve partnered with Appboy to provide deep linking with Appboy's push service. Learn how to set it up.
+keywords: Contextual Deep Linking, Deep links, Deeplinks, Deep Linking, Deeplinking, Deferred Deep Linking, Deferred Deeplinking, Google App Indexing, Google App Invites, Apple Universal Links, Apple Spotlight Search, Facebook App Links, AppLinks, Deepviews, Deep views, Analytics, Install Data, Appboy
+hide_platform_selector: true
+premium: false
+sections:
+- guide
+alias: [ /third-party-integrations/appboy/, /third-party-integrations/appboy/overview/, /third-party-integrations/appboy/guide/, /third-party-integrations/appboy/support/ ] 
+---
+
+{% prerequisite %}
+
+- This guide requires you to have already [integrated the Branch SDK]({{base.url}}/getting-started/sdk-integration-guide) into your app.
+- You also need to [sign up for an Appboy account](https://dashboard.appboy.com/developers/sign_up) and [install the Appboy SDK](https://documentation.appboy.com/).
+- Ensure Appboy's SDK is [collecting the IDFA](https://documentation.appboy.com/iOS/#optional-idfa-collection).
+
+{% endprerequisite %}
+
+## How to use Branch Links to Deep Link from Appboy's In-App Message Campaigns on iOS
+
+1. Ensure that the type of campaign you are running is an **In-App Message** campaign.
+2. From Appboy's Dashboard, **Edit** your campaign.
+3. From the **Compose** tab scroll down to **iOS**.
+4. Within the **On-click Behavior** section, select **Deep Link Into App** or **Redirect to Web URL**.
+5. To understand what to insert into this field, find a Branch Marketing link you would like users to get deep linked to and then follow the instructions [here](https://dev.branch.io/features/facebook-ads/support/ios/#use-a-direct-deep-link).
+6. **Update** your campaign.
+
+## Handle Branch links in Appboy delegate
+
+{% tabs %}
+{% tab objective-c %}
+
+Open your **AppDelegate.m** file and add the following method (if you completed the SDK Integration Guide of Appboy, this is likely already present).
+
+{% highlight objc %}
+- (BOOL)handleAppboyURL:(NSURL *)url fromChannel:(ABKChannel)channel withExtras:(NSDictionary *)extras {
+    BOOL handledByBranch = [[Branch getInstance] handleDeepLinkWithNewSession:url];
+    if (handledByBranch) {
+        return YES;
+    }
+  // Let Appboy handle links otherwise
+    return NO; 
+}
+{% endhighlight %}
+{% endtab %}
+{% tab swift %}
+
+Open your **AppDelegate.swift** file and add the following method (if you completed the [SDK Integration Guide]({{base.url}}/getting-started/sdk-integration-guide), this is likely already present).
+
+{% highlight swift %}
+func handleAppboyURL(_ url: URL, from channel: ABKChannel, withExtras extras: [AnyHashable : Any]) -> Bool {
+    let handleByBranch = Branch.getInstance().handleDeepLinkWithNewSession(url)
+    if handleByBranch {
+        return false
+    }
+    // Let Appboy handle links otherwise
+    return true
+}
+{% endhighlight %}
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
Guide to integrate Branch with Appboy is added under section marketing-channel -> Push service -> Appboy push service
http://127.0.0.1:4000/marketing-channels/appboy-push-service/overview/

While the Appboy in Data-Integration section is changed, where the support section is removed.