### PR TITLE
fix: broken link on

### DIFF
--- a/pages/marketing-channels/spotlight-indexing.md
+++ b/pages/marketing-channels/spotlight-indexing.md
@@ -10,7 +10,7 @@ sections:
 - overview
 - guide
 - advanced
-alias: [ /features/spotlight-indexing/overview/, /features/spotlight-indexing/overview/, /features/spotlight-indexing/guide/, /features/spotlight-indexing/advanced/ ] 
+alias: [ /features/spotlight-indexing/, /features/spotlight-indexing/overview/, /features/spotlight-indexing/guide/, /features/spotlight-indexing/advanced/ ] 
 ---
 
 {% if page.overview %}


### PR DESCRIPTION
@aaaronlopez this is the fix for the broken link. We recently did a navigation change on the documentation which changes the locations of all our pages. The link on https://dev.branch.io/getting-started/branch-universal-object/guide/ios/#listonspotlightwithcallback was still pointing to the old page location. I updated the `alias` on the new page so the old link will redirect correctly.

<img width="847" alt="screen shot 2017-07-12 at 3 55 58 pm" src="https://user-images.githubusercontent.com/2933593/28143491-a4fe52fe-671a-11e7-998c-f63a96828eb1.png">
