### PR TITLE
Add docs for passing referring link data in CTA

### DIFF
--- a/pages/marketing-channels/journeys.md
+++ b/pages/marketing-channels/journeys.md
@@ -100,6 +100,8 @@ branch.setBranchViewData({
 {% endhighlight %}
 {% endprotip %}
 
+If a user is referred to a page running Journeys via a Branch link, then referring link data will be passed into the Journeys call-to-action by default. If you’re using setBranchViewData() to specify link data for Journeys on that page, the only data from setBranchViewData() that will be used are [dynamic Journeys layout parameters](https://dev.branch.io/marketing-channels/journeys/advanced/#dynamic-journeys-layout-customization); all other data in that call will be ignored, unless `make_new_link` is set to `true` in `branch.init()`. You can find more information [here](https://dev.branch.io/marketing-channels/journeys/guide/#preserve-discard-referring-link-data).
+
 **Note:** You should [integrate the Branch SDK]({{base.url}}/getting-started/sdk-integration-guide) into your app and [configure deep link routing]({{base.url}}/getting-started/deep-link-routing) for deferred deep linking and attribution.
 
 ## Create Journey banner or interstitial
@@ -280,6 +282,22 @@ You can also access Journeys analytics by selecting the above filters from the [
 
 {% elsif page.advanced %}
 
+### Preserve/discard referring link data
+
+By default, when users arrive on a page running Journeys via a Branch link and `make_new_link` is not set to `true`, then any interaction with the Journey (click/install/re-open) will be attributed to the referring Branch link, rather than to the Journey. If `make_new_link` is set to `true`, the same events will be attributed to the Journey, instead.
+
+This can help you collect data on how the referring links are contributing to app growth/engagement, even when users aren’t installing from those links directly. For example, if a user clicked a Branch link on Facebook, landed on your website, and installed from a Journey, this would allow you to attribute the install to the link on Facebook. If the original link was also configured to deep link into your app, that deep link would be preserved, too.
+
+Branch will pass the referring link into Journeys by default. In order to discard referring link data, include the `make_new_link flag`, with a value of  `true`, into the options during initialization:
+
+{% highlight javascript %}
+branch.init( ‘BRANCH_KEY’,
+    {
+    	‘make_new_link’ : true
+    }
+);
+{% endhighlight %}
+
 ## Advanced audience rules
 
 You can target users on a more granular level - based on behavior like where they came from, whether they already have your app installed, and what they’ve done on your website or in your app. We've created a bunch of great examples on the [next tab]({{base.url}}/features/journeys/examples).
@@ -353,7 +371,6 @@ We ask you to prioritize all non-Archived Journeys because Journeys can be set l
 
 ##### What happens if I have some Journeys with priorities set and some without?
 We recommend setting priority for all Journeys. All new Journeys you create will automatically have the lowest priority assigned to them, as well as *Draft* or *Stopped* Journeys *without priority* that are set live (Journeys with priority will not have their priority changed unless you explicitly set them). If you don't set a priority for all your Journeys, then any matching Journey (i.e. Journey passing the audience filter you set) without priority will be picked at random to show.
-
 
 ## Dynamic Journeys layout customization
 
@@ -799,7 +816,7 @@ Next, you'll choose the `More than or equal to` in the middle section:
 
 {% image src='/img/pages/features/journeys/examples/retargeting_users_2.png' center full alt='retargeting users 2' %}
 
-Finally, you'll enter 3 in the last part to indicate you want to target people who have completed `MyAction more than 2 times historically.
+Finally, you'll enter 3 in the last part to indicate you want to target people who have completed `MyAction` more than 2 times historically.
 
 {% image src='/img/pages/features/journeys/examples/retargeting_users_3.png' center full alt='retargeting users 3' %}
 

--- a/pages/marketing-channels/journeys.md
+++ b/pages/marketing-channels/journeys.md
@@ -16,6 +16,8 @@ sections:
 contents:
   number:
     - amp
+  hide:
+    - examples
 alias: [ /features/journeys/, /features/journeys/overview/, /features/journeys/guide/, /features/journeys/advanced/, /features/journeys/examples/ ]
 ---
 
@@ -100,7 +102,7 @@ branch.setBranchViewData({
 {% endhighlight %}
 {% endprotip %}
 
-If a user is referred to a page running Journeys via a Branch link, then referring link data will be passed into the Journeys call-to-action by default. If you’re using setBranchViewData() to specify link data for Journeys on that page, the only data from setBranchViewData() that will be used are [dynamic Journeys layout parameters](https://dev.branch.io/marketing-channels/journeys/advanced/#dynamic-journeys-layout-customization); all other data in that call will be ignored, unless `make_new_link` is set to `true` in `branch.init()`. You can find more information [here](https://dev.branch.io/marketing-channels/journeys/guide/#preserve-discard-referring-link-data).
+If a user is referred to a page running Journeys via a Branch link, then referring link data will be passed into the Journeys call-to-action by default. If you’re using setBranchViewData() to specify link data for Journeys on that page, the only data from setBranchViewData() that will be used are [dynamic Journeys layout parameters]({{base.url}}/marketing-channels/journeys/advanced/#dynamic-journeys-layout-customization); all other data in that call will be ignored, unless `make_new_link` is set to `true` in `branch.init()`. You can find more information [here]({{base.url}}/marketing-channels/journeys/advanced/#preserve-or-discard-referring-link-data).
 
 **Note:** You should [integrate the Branch SDK]({{base.url}}/getting-started/sdk-integration-guide) into your app and [configure deep link routing]({{base.url}}/getting-started/deep-link-routing) for deferred deep linking and attribution.
 
@@ -125,7 +127,7 @@ If you have users in many countries, you can create a separate Journey for each 
 | Platform | Branch currently offers Journeys on one platform: **Mobile web**. This will display for mobile users on your website. _More options coming soon._
 | Devices | Which devices would you like to target? For example, if you only have an iOS app, then you might want to show a Journey only to users viewing your mobile website on iOS.
 | Regions {% premiumflag %}{% endpremiumflag %} | Select one or more countries in which to display your Journey. Defaults to **Show to All Regions**
-| Additional Filters {% premiumflag %}{% endpremiumflag %} | Read about advanced filtering criteria [here]({{base.url}}/features/journeys/advanced/#advanced-audience-rules).
+| Additional Filters {% premiumflag %}{% endpremiumflag %} | Read about advanced filtering criteria [here]({{base.url}}/marketing-channels/journeys/advanced/#advanced-audience-rules).
 
 ## Select and style the banner or interstitial
 
@@ -278,25 +280,15 @@ You can also access Journeys analytics by selecting the above filters from the [
 1. Filter by `feature` = `journeys`
 2. Filter by `campaign` = `[Journey Name]`
 
+{% protip title="Attribute Journeys events to referring links" %}
+
+By default, when users arrive on a page running Journeys via a Branch link, then any interaction with the Journey (click/install/re-open) will be attributed to the referring Branch link, rather than to the Journey. [Learn how]({{base.url}}/marketing-channels/journeys/advanced/#preserve-or-discard-referring-link-data) to attribute this data to the Journey instead.
+
+{% endprotip %}
+
 {% getstarted next="true" %}{% endgetstarted %}
 
 {% elsif page.advanced %}
-
-### Preserve/discard referring link data
-
-By default, when users arrive on a page running Journeys via a Branch link and `make_new_link` is not set to `true`, then any interaction with the Journey (click/install/re-open) will be attributed to the referring Branch link, rather than to the Journey. If `make_new_link` is set to `true`, the same events will be attributed to the Journey, instead.
-
-This can help you collect data on how the referring links are contributing to app growth/engagement, even when users aren’t installing from those links directly. For example, if a user clicked a Branch link on Facebook, landed on your website, and installed from a Journey, this would allow you to attribute the install to the link on Facebook. If the original link was also configured to deep link into your app, that deep link would be preserved, too.
-
-Branch will pass the referring link into Journeys by default. In order to discard referring link data, include the `make_new_link flag`, with a value of  `true`, into the options during initialization:
-
-{% highlight javascript %}
-branch.init( ‘BRANCH_KEY’,
-    {
-    	‘make_new_link’ : true
-    }
-);
-{% endhighlight %}
 
 ## Advanced audience rules
 
@@ -357,6 +349,22 @@ Note that if you are planning on just using the free banner, you can skip this s
 - Your total percentage allocation must not equal more than **100%**.
 - Your total percentage allocation may be _less_ than **100%**. In this situation, the remainder of your audience will be shown your standard website without a Journey. This allows you to A/B test against your non-Journeys website experience.
 {% endprotip %}
+
+## Preserve or discard referring link data
+
+By default, when users arrive on a page running Journeys via a Branch link and `make_new_link` is not set to `true`, then any interaction with the Journey (click/install/re-open) will be attributed to the referring Branch link, rather than to the Journey. If `make_new_link` is set to `true`, the same events will be attributed to the Journey, instead.
+
+This can help you collect data on how the referring links are contributing to app growth/engagement, even when users aren’t installing from those links directly. For example, if a user clicked a Branch link on Facebook, landed on your website, and installed from a Journey, this would allow you to attribute the install to the link on Facebook. If the original link was also configured to deep link into your app, that deep link would be preserved, too.
+
+Branch will pass the referring link into Journeys by default. In order to discard referring link data, include the `make_new_link` flag, with a value of  `true`, into the options during initialization:
+
+{% highlight javascript %}
+branch.init( 'BRANCH_KEY',
+    {
+        'make_new_link' : true
+    }
+);
+{% endhighlight %}
 
 ## Prioritization
 


### PR DESCRIPTION
changes to "Deep linking from the banner or interstitial" and "Visualizing Journeys performance" sections of Journeys docs