### PR TITLE
Facebook ads url redirection

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,3 @@ exclude:
 
 sass:
     sass_dir: css
-
-gems:
-  - jekyll-redirect-from

--- a/_config_live.yml
+++ b/_config_live.yml
@@ -32,6 +32,3 @@ exclude:
 
 sass:
     sass_dir: css
-
-gems:
-  - jekyll-redirect-from

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -32,6 +32,3 @@ exclude:
 
 sass:
     sass_dir: css
-
-gems:
-  - jekyll-redirect-from

--- a/pages/marketing-channels/facebook-ads-overview.md
+++ b/pages/marketing-channels/facebook-ads-overview.md
@@ -7,10 +7,7 @@ description:
 hide_platform_selector: true
 sections:
 - overview
-redirect_from:
-  - /features/facebook-ads-overview/
-  - /features/facebook-ads/
-  - /features/facebook-ads/guide/
+alias: [ /features/facebook-ads-overview/ ]
 ---
 
 {% if page.overview %}

--- a/pages/marketing-channels/facebook-ads-overview.md
+++ b/pages/marketing-channels/facebook-ads-overview.md
@@ -7,7 +7,7 @@ description:
 hide_platform_selector: true
 sections:
 - overview
-alias: [ /features/facebook-ads-overview/ ]
+alias: [ /features/facebook-ads-overview/, /features/facebook-ads-overview/overview/ ]
 ---
 
 {% if page.overview %}


### PR DESCRIPTION
_config.yml files for live and staging have incorrect baseurl setups, should be nil values

This causes the jekyll-redirect-from gem to work incorrectly. -> Reverting usage of this gem.