### PR TITLE
Length of the Identity

### DIFF
--- a/pages/cross-channel-analytics/growth-attribution.md
+++ b/pages/cross-channel-analytics/growth-attribution.md
@@ -231,7 +231,7 @@ branch.logout();
 
 {% caution %}
 
-The length of the User ID you use to identify your users should not be more than 127 characters.
+The length of the User ID you assign to identify your users should not be more than 127 characters.
 
 {% endcaution %}
 

--- a/pages/cross-channel-analytics/growth-attribution.md
+++ b/pages/cross-channel-analytics/growth-attribution.md
@@ -229,6 +229,12 @@ branch.logout();
 {% endhighlight %}
 {% endif %}
 
+{% caution %}
+
+The length of the User ID you use to identify your users should not be more than 127 characters.
+
+{% endcaution %}
+
 {% protip title="Retroactive event attribution" %}
 The **first** time an identity is set for each unique user ID, it will retroactively associate any previously recorded events from the current device with that user ID. This only occurs once.
 {% endprotip %}


### PR DESCRIPTION
Change: 
Added a note on the identity length for users cannot be more than 127 characters.

Tests:
Tested the documentation website locally
